### PR TITLE
Rebased on the Gtk3 branch and squashed my commits

### DIFF
--- a/code/caja-terminal-preferences.glade
+++ b/code/caja-terminal-preferences.glade
@@ -980,7 +980,6 @@
     <property name="destroy_with_parent">True</property>
     <property name="type_hint">normal</property>
     <property name="skip_taskbar_hint">True</property>
-    <property name="has_separator">False</property>
     <property name="program_name">Caja Terminal</property>
     <property name="copyright">Copyright (C) 2010 Fabien Loison</property>
     <property name="comments" translatable="yes">An integrated terminal for Caja</property>
@@ -1032,7 +1031,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
     <property name="destroy_with_parent">True</property>
     <property name="type_hint">normal</property>
     <property name="skip_taskbar_hint">True</property>
-    <property name="has_separator">False</property>
     <property name="action">select-folder</property>
     <signal name="delete_event" handler="on_filechooser_delete_event"/>
     <child internal-child="vbox">

--- a/code/caja-terminal.py
+++ b/code/caja-terminal.py
@@ -598,12 +598,12 @@ class CajaTerminalPref(object):
             colors = self._conf['color_palette']
         else:
             colors = PREDEF_PALETTE['Tango']
-        fg = self.clbtnFg.get_color()
-        bg = self.clbtnBg.get_color()
+        fg = Gdk.RGBA().from_color(self.clbtnFg.get_color())
+        bg = Gdk.RGBA().from_color(self.clbtnBg.get_color())
         palette = []
         for i in xrange(16):
-            palette.append(Gdk.color_parse(colors[i]))
-            self.clbtnPalette[i].set_color(palette[i])
+            palette.append(Gdk.RGBA().from_color(Gdk.color_parse(colors[i])))
+            self.clbtnPalette[i].set_color(palette[i].to_color())
         self.demoTerm.set_colors(fg, bg, palette)
 
     def _remove_path_from_list(self, gtktree, gtklist, conflist):
@@ -753,9 +753,9 @@ class CajaTerminal(GObject.GObject, Caja.LocationWidgetProvider):
         terminal.connect("focus", self.on_terminal_need_child,
                 window, terminal, sclwinTerm, path,
                 )
-        terminal.connect("expose-event", self.on_terminal_need_child,
-                window, terminal, sclwinTerm, path,
-                )
+#        terminal.connect("expose-event", self.on_terminal_need_child,
+#                window, terminal, sclwinTerm, path,
+#                )
         terminal.connect("button-press-event", self.on_terminal_need_child,
                 window, terminal, sclwinTerm, path,
                 )
@@ -764,13 +764,13 @@ class CajaTerminal(GObject.GObject, Caja.LocationWidgetProvider):
                 )
         terminal.connect("key-release-event", self.on_terminal_key_release_event)
         #DnD
-        terminal.drag_dest_set(
-                Gtk.DestDefaults.MOTION |
-                Gtk.DestDefaults.HIGHLIGHT |
-                Gtk.DestDefaults.DROP,
-                [('text/uri-list', 0, 80)],
-                Gdk.DragAction.COPY,
-                )
+#        terminal.drag_dest_set(
+#                Gtk.DestDefaults.MOTION |
+#                Gtk.DestDefaults.HIGHLIGHT |
+#                Gtk.DestDefaults.DROP,
+#                [('text/uri-list', 0, 80)],
+#                Gdk.DragAction.COPY,
+#                )
         terminal.connect("drag_motion", self.on_terminal_drag_motion)
         terminal.connect("drag_drop", self.on_terminal_drag_drop)
         terminal.connect("drag_data_received", self.on_terminal_drag_data_received)
@@ -918,12 +918,13 @@ class CajaTerminal(GObject.GObject, Caja.LocationWidgetProvider):
     def on_evResize_enter_notify_event(self, widget, event, rwidget):
         width, height = rwidget.get_size_request()
         rwidget.set_size_request(width, height)
-        cursor = Gdk.Cursor(Gdk.CursorType.SB_V_DOUBLE_ARROW)
-        widget.window.set_cursor(cursor)
+#        cursor = Gdk.Cursor(Gdk.CursorType.SB_V_DOUBLE_ARROW)
+#        widget.window.set_cursor(cursor)
 
     def on_evResize_leave_notify_event(self, widget, event):
-        cursor = Gdk.Cursor(Gdk.CursorType.ARROW)
-        widget.window.set_cursor(cursor)
+        return
+#        cursor = Gdk.Cursor(Gdk.CursorType.ARROW)
+#        widget.window.set_cursor(cursor)
 
     def on_evResize_motion_notify_event(self, widget, event, rwidget, term, window):
         width, height = rwidget.get_size_request()

--- a/code/caja-terminal.py
+++ b/code/caja-terminal.py
@@ -487,7 +487,7 @@ class CajaTerminalPref(object):
 
     def on_clbtnPalette_color_set(self, widget, index=0):
         """General method for on_color_set"""
-        changed_color = str(widget.get_color())
+        changed_color = widget.get_color().to_string()
         if self._conf['color_palettename'] != "Custom":
             self._conf['color_palette'] = list(
                     PREDEF_PALETTE[self._conf['color_palettename']]

--- a/code/caja-terminal.py
+++ b/code/caja-terminal.py
@@ -744,9 +744,7 @@ class CajaTerminal(GObject.GObject, Caja.LocationWidgetProvider):
                 )
         #Terminal
         terminal.connect("destroy", self.on_terminal_destroy, window)
-        terminal.connect("child-exited", self.on_terminal_child_exited,
-                terminal,
-                )
+        terminal.connect("child-exited", self.on_terminal_child_exited)
         terminal.connect("commit", self.on_terminal_commit,
                 window, sclwinTerm, path,
                 )
@@ -856,7 +854,7 @@ class CajaTerminal(GObject.GObject, Caja.LocationWidgetProvider):
             finally:
                 window.nt_lastpid = -1
 
-    def on_terminal_child_exited(self, widget, terminal):
+    def on_terminal_child_exited(self, terminal, status):
         terminal.has_child = False
 
     def on_terminal_commit(self, widget, char, size, window, rwidget, path):


### PR DESCRIPTION
1. More use of Gdk.RGBA
2. Commented 'expose-event' signal connection
3. Commented the call of terminal.drag_dest_set()
4. Commented the call of widget.window.set_cursor in on_evResize_enter_notify_event() and on_evResize_leave_notify_event
5. Removed <property name="has_separator">False</property> from preferences glade file (thanks for Wolfgang Ulbrich)